### PR TITLE
Message Channel Event

### DIFF
--- a/slack_app_manifest.yml
+++ b/slack_app_manifest.yml
@@ -43,6 +43,7 @@ settings:
       - app_mention
       - file_shared
       - member_joined_channel
+      - message.channels
       - reaction_added
       - team_join
   interactivity:

--- a/slack_app_manifest_template.yml
+++ b/slack_app_manifest_template.yml
@@ -43,6 +43,7 @@ settings:
       - app_mention
       - file_shared
       - member_joined_channel
+      - message.channels
       - reaction_added
       - team_join
   interactivity:


### PR DESCRIPTION
This PR updates the slack manifest which was missing the `message.channels` event subscription. This ensures that the bot responds to messages posted in public channels.