### PR TITLE
Remove Chalk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@slack/bolt": "^3.19.0",
         "axios": "^1.10.0",
-        "chalk": "^4.1.2",
         "dotenv": "^16.4.5",
         "node-cron": "^3.0.3",
         "openai": "^4.21.0"
@@ -399,21 +398,6 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -679,43 +663,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -740,24 +687,6 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@slack/bolt": "^3.19.0",
     "axios": "^1.10.0",
-    "chalk": "^4.1.2",
     "dotenv": "^16.4.5",
     "node-cron": "^3.0.3",
     "openai": "^4.21.0"

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -4,23 +4,35 @@ const config = require('../config');
 
 // Minimal terminal color utility
 const colorEnabled = process.stdout.isTTY && config.NODE_ENV !== 'production';
+
+// ANSI escape codes as constants
+const ANSI_RESET = "\x1b[0m";
+const ANSI_BOLD = "\x1b[1m";
+const ANSI_DIM = "\x1b[2m";
+const ANSI_CYAN = "\x1b[36m";
+const ANSI_GREEN = "\x1b[32m";
+const ANSI_YELLOW = "\x1b[33m";
+const ANSI_RED = "\x1b[31m";
+const ANSI_MAGENTA = "\x1b[35m";
+const ANSI_BLUE = "\x1b[34m";
+
 const color = {
-  reset: "\x1b[0m",
-  bold: "\x1b[1m",
-  dim: "\x1b[2m",
-  cyan: (str) => colorEnabled ? `\x1b[36m${str}${color.reset}` : str,
-  green: (str) => colorEnabled ? `\x1b[32m${str}${color.reset}` : str,
-  yellow: (str) => colorEnabled ? `\x1b[33m${str}${color.reset}` : str,
-  red: (str) => colorEnabled ? `\x1b[31m${str}${color.reset}` : str,
-  magenta: (str) => colorEnabled ? `\x1b[35m${str}${color.reset}` : str,
-  blue: (str) => colorEnabled ? `\x1b[34m${str}${color.reset}` : str,
-  boldCyan: (str) => colorEnabled ? `${color.bold}\x1b[36m${str}${color.reset}` : str,
-  boldGreen: (str) => colorEnabled ? `${color.bold}\x1b[32m${str}${color.reset}` : str,
-  boldYellow: (str) => colorEnabled ? `${color.bold}\x1b[33m${str}${color.reset}` : str,
-  boldRed: (str) => colorEnabled ? `${color.bold}\x1b[31m${str}${color.reset}` : str,
-  boldBlue: (str) => colorEnabled ? `${color.bold}\x1b[34m${str}${color.reset}` : str,
-  dimText: (str) => colorEnabled ? `${color.dim}${str}${color.reset}` : str,
-  dimMagenta: (str) => colorEnabled ? `${color.dim}\x1b[35m${str}${color.reset}` : str,
+  reset: ANSI_RESET,
+  bold: ANSI_BOLD,
+  dim: ANSI_DIM,
+  cyan: (str) => colorEnabled ? `${ANSI_CYAN}${str}${ANSI_RESET}` : str,
+  green: (str) => colorEnabled ? `${ANSI_GREEN}${str}${ANSI_RESET}` : str,
+  yellow: (str) => colorEnabled ? `${ANSI_YELLOW}${str}${ANSI_RESET}` : str,
+  red: (str) => colorEnabled ? `${ANSI_RED}${str}${ANSI_RESET}` : str,
+  magenta: (str) => colorEnabled ? `${ANSI_MAGENTA}${str}${ANSI_RESET}` : str,
+  blue: (str) => colorEnabled ? `${ANSI_BLUE}${str}${ANSI_RESET}` : str,
+  boldCyan: (str) => colorEnabled ? `${ANSI_BOLD}${ANSI_CYAN}${str}${ANSI_RESET}` : str,
+  boldGreen: (str) => colorEnabled ? `${ANSI_BOLD}${ANSI_GREEN}${str}${ANSI_RESET}` : str,
+  boldYellow: (str) => colorEnabled ? `${ANSI_BOLD}${ANSI_YELLOW}${str}${ANSI_RESET}` : str,
+  boldRed: (str) => colorEnabled ? `${ANSI_BOLD}${ANSI_RED}${str}${ANSI_RESET}` : str,
+  boldBlue: (str) => colorEnabled ? `${ANSI_BOLD}${ANSI_BLUE}${str}${ANSI_RESET}` : str,
+  dimText: (str) => colorEnabled ? `${ANSI_DIM}${str}${ANSI_RESET}` : str,
+  dimMagenta: (str) => colorEnabled ? `${ANSI_DIM}${ANSI_MAGENTA}${str}${ANSI_RESET}` : str,
 };
 
 class Logger {

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -27,8 +27,6 @@ class Logger {
   constructor() {
     this.startTime = Date.now(); // when did we start this mess?
     this.useJsonLogs = config.JSON_LOGS;
-
-  // Color output is controlled by colorEnabled flag in color utility
   }
 
   _formatTime() {
@@ -45,8 +43,8 @@ class Logger {
     if (typeof data === 'string') {
       // hide the secret sauce
       return data.replace(/sk-[a-zA-Z0-9]{48}/g, 'sk-***HIDDEN***')
-                 .replace(/xox[a-z]-[a-zA-Z0-9-]+/g, 'xox*-***HIDDEN***')
-                 .replace(/asst_[a-zA-Z0-9]+/g, 'asst_***HIDDEN***');
+        .replace(/xox[a-z]-[a-zA-Z0-9-]+/g, 'xox*-***HIDDEN***')
+        .replace(/asst_[a-zA-Z0-9]+/g, 'asst_***HIDDEN***');
     }
 
     if (typeof data === 'object' && data !== null) {
@@ -139,11 +137,11 @@ class Logger {
   }
 
   bot(botName, message, data = null) {
-  this._logWithData(botName.toUpperCase(), color.boldBlue, message, data);
+    this._logWithData(botName.toUpperCase(), color.boldBlue, message, data);
   }
 
   slack(action, data = null) {
-  this._logWithData('SLACK', color.boldCyan, action, data);
+    this._logWithData('SLACK', color.boldCyan, action, data);
   }
 
   openai(action, data = null) {

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,18 +1,34 @@
 // logging utility with sensitive data protection
 
 const config = require('../config');
-const chalk = require('chalk');
+
+// Minimal terminal color utility
+const colorEnabled = process.stdout.isTTY && config.NODE_ENV !== 'production';
+const color = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  cyan: (str) => colorEnabled ? `\x1b[36m${str}${color.reset}` : str,
+  green: (str) => colorEnabled ? `\x1b[32m${str}${color.reset}` : str,
+  yellow: (str) => colorEnabled ? `\x1b[33m${str}${color.reset}` : str,
+  red: (str) => colorEnabled ? `\x1b[31m${str}${color.reset}` : str,
+  magenta: (str) => colorEnabled ? `\x1b[35m${str}${color.reset}` : str,
+  blue: (str) => colorEnabled ? `\x1b[34m${str}${color.reset}` : str,
+  boldCyan: (str) => colorEnabled ? `${color.bold}\x1b[36m${str}${color.reset}` : str,
+  boldGreen: (str) => colorEnabled ? `${color.bold}\x1b[32m${str}${color.reset}` : str,
+  boldYellow: (str) => colorEnabled ? `${color.bold}\x1b[33m${str}${color.reset}` : str,
+  boldRed: (str) => colorEnabled ? `${color.bold}\x1b[31m${str}${color.reset}` : str,
+  boldBlue: (str) => colorEnabled ? `${color.bold}\x1b[34m${str}${color.reset}` : str,
+  dimText: (str) => colorEnabled ? `${color.dim}${str}${color.reset}` : str,
+  dimMagenta: (str) => colorEnabled ? `${color.dim}\x1b[35m${str}${color.reset}` : str,
+};
 
 class Logger {
   constructor() {
     this.startTime = Date.now(); // when did we start this mess?
     this.useJsonLogs = config.JSON_LOGS;
 
-    // Configure chalk based on environment
-    // Note: Chalk automatically detects TTY, but we can override for production
-    if (config.NODE_ENV === 'production' || !process.stdout.isTTY) {
-      chalk.level = 0; // Disable colors
-    }
+  // Color output is controlled by colorEnabled flag in color utility
   }
 
   _formatTime() {
@@ -73,24 +89,25 @@ class Logger {
     }
 
     const timestamp = this._formatTime();
-    console.log(`${chalk.cyan(`[${timestamp}]`)} ${levelColor(level)} ${message}`);
+
+    console.log(`${color.cyan(`[${timestamp}]`)} ${levelColor(level)} ${message}`);
 
     if (data) {
       const sanitized = this._sanitizeData(data);
-      console.log(chalk.dim(`   └─ ${JSON.stringify(sanitized, null, 2)}`));
+      console.log(color.dimText(`   └─ ${JSON.stringify(sanitized, null, 2)}`));
     }
   }
 
   info(message, data = null) {
-    this._logWithData('INFO', chalk.bold.cyan, message, data);
+    this._logWithData('INFO', color.boldCyan, message, data);
   }
 
   success(message, data = null) {
-    this._logWithData('SUCCESS', chalk.bold.green, message, data);
+    this._logWithData('SUCCESS', color.boldGreen, message, data);
   }
 
   warning(message, data = null) {
-    this._logWithData('WARNING', chalk.bold.yellow, message, data);
+    this._logWithData('WARNING', color.boldYellow, message, data);
   }
 
   error(message, error = null) {
@@ -100,37 +117,37 @@ class Logger {
     }
 
     const timestamp = this._formatTime();
-    console.log(`${chalk.cyan(`[${timestamp}]`)} ${chalk.bold.red('ERROR')} ${message}`);
+    console.log(`${color.cyan(`[${timestamp}]`)} ${color.boldRed('ERROR')} ${message}`);
 
     if (error) {
       if (error instanceof Error) {
-        console.log(chalk.dim(`   └─ ${error.message}`));
+        console.log(color.dimText(`   └─ ${error.message}`));
         if (error.stack) {
-          console.log(chalk.dim(`   └─ Stack: ${error.stack}`));
+          console.log(color.dimText(`   └─ Stack: ${error.stack}`));
         }
       } else {
         const sanitized = this._sanitizeData(error);
-        console.log(chalk.dim(`   └─ ${JSON.stringify(sanitized, null, 2)}`));
+        console.log(color.dimText(`   └─ ${JSON.stringify(sanitized, null, 2)}`));
       }
     }
   }
 
   debug(message, data = null) {
     if (config.DEBUG) {
-      this._logWithData('DEBUG', chalk.dim.magenta, message, data);
+      this._logWithData('DEBUG', color.dimMagenta, message, data);
     }
   }
 
   bot(botName, message, data = null) {
-    this._logWithData(botName.toUpperCase(), chalk.bold.blue, message, data);
+  this._logWithData(botName.toUpperCase(), color.boldBlue, message, data);
   }
 
   slack(action, data = null) {
-    this._logWithData('SLACK', chalk.bold.cyan, action, data);
+  this._logWithData('SLACK', color.boldCyan, action, data);
   }
 
   openai(action, data = null) {
-    this._logWithData('OPENAI', chalk.bold.green, action, data);
+    this._logWithData('OPENAI', color.boldGreen, action, data);
   }
 
   startup(message) {
@@ -141,7 +158,7 @@ class Logger {
     if (this.useJsonLogs) {
       return;
     }
-    console.log(chalk.dim('─'.repeat(60)));
+    console.log(color.dimText('─'.repeat(60)));
   }
 }
 


### PR DESCRIPTION
This PR removes chalk from the logging utility per https://github.com/advisories/GHSA-2v46-p5h4-248w. While our version is not strictly affected, this is out of an abundance of caution. Deployed and validated in DEV.

See also:  https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised